### PR TITLE
feat: Anthropic-inspired UI redesign

### DIFF
--- a/hosting/gatsby-config.js
+++ b/hosting/gatsby-config.js
@@ -24,8 +24,8 @@ module.exports = {
         name: 'pricetrack',
         short_name: 'pricetrack',
         start_url: '/?utm_source=homescreen&utm_medium=shortcut',
-        background_color: '#f8f9fa',
-        theme_color: '#f8f9fa',
+        background_color: '#faf9f5',
+        theme_color: '#cc785c',
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: 'standalone',

--- a/hosting/src/components/Block/CrawlerStatus.js
+++ b/hosting/src/components/Block/CrawlerStatus.js
@@ -55,7 +55,7 @@ export default class CrawlerStatus extends Component {
     ));
 
     return (
-      <table className="table">
+      <table className="pt-table">
         <thead>
           <tr>
             <th scope="col">Dịch vụ</th>

--- a/hosting/src/components/Block/FlashMessage.js
+++ b/hosting/src/components/Block/FlashMessage.js
@@ -1,17 +1,5 @@
 import React from 'react';
 
-const style = {
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  textAlign: 'center',
-  background: '#ff3030cc',
-  right: 0,
-  color: '#fff',
-  fontSize: 'small',
-  padding: '5px'
-};
-
 const DEFAULT_ERROR_MESSAGE = 'Something went wrong!';
 export default class FlashMessage extends React.Component {
     state = {
@@ -34,7 +22,7 @@ export default class FlashMessage extends React.Component {
     render() {
       if (this.state.timer > 0) {
         return (
-            <div style={style}>{this.props.message || DEFAULT_ERROR_MESSAGE}</div>
+            <div className="pt-flash">{this.props.message || DEFAULT_ERROR_MESSAGE}</div>
         );
       }
       return null;

--- a/hosting/src/components/Block/HeadSlogan.js
+++ b/hosting/src/components/Block/HeadSlogan.js
@@ -6,11 +6,6 @@ import IMG_IMAGE from '../../../static/animat-image-color.gif';
 
 const HEAD_LINE_PRICE_TRACKER = 'Theo dõi giá';
 
-const style = {
-  background: '#fff',
-  borderRadius: 5
-};
-
 const icons = {
   linechart: IMG_LINECHART,
   checkmark: IMG_CHECKMARK,
@@ -19,10 +14,12 @@ const icons = {
 
 export default (props) => (
     <div className="d-flex flex-grow-1 align-items-center">
-        <img className="mr-3" src={icons[props.icon || 'linechart']} alt="" width="48" height="48" style={style} />
-        <div className="lh-100">
-            <h6 className="mb-0 text-white lh-100">{props.headline || HEAD_LINE_PRICE_TRACKER}</h6>
-            <small>{props.sub_headline || 'beta'}</small>
+        <div className="pt-hero-icon">
+            <img src={icons[props.icon || 'linechart']} alt="" width="28" height="28" />
+        </div>
+        <div>
+            <h2 style={{ margin: 0 }}>{props.headline || HEAD_LINE_PRICE_TRACKER}</h2>
+            <p>{props.sub_headline || 'beta'}</p>
         </div>
     </div>
 );

--- a/hosting/src/components/Block/Loading.js
+++ b/hosting/src/components/Block/Loading.js
@@ -1,6 +1,9 @@
 import React from 'react';
 
-const spinnersClass = ['primary', 'secondary', 'success', 'danger'];
-const spinners = spinnersClass.map((i) => <div className={`spinner-grow text-${i}`} role="status" key={i} />);
-
-export default () => <div className="d-flex justify-content-center">{spinners}</div>;
+export default () => (
+  <div className="pt-loading">
+    <span className="pt-loading-dot" />
+    <span className="pt-loading-dot" />
+    <span className="pt-loading-dot" />
+  </div>
+);

--- a/hosting/src/components/Block/ProductList.js
+++ b/hosting/src/components/Block/ProductList.js
@@ -26,67 +26,66 @@ class ProductList extends React.Component {
     if (!this.props.urls.length) return EMPTY_STRING;
 
     const dom = this.props.urls.map((url) => (
-        <div className="media text-muted pt-3 d-flex justify-content-between align-items-center flex-sm-row flex-column border-bottom border-gray" key={url.url}>
-          <div className="d-flex justify-content-center">
-            <div className="d-flex flex-column align-items-center">
-                <LogoPlaceHolder className="d-block" url={url} />
-                <A className="d-block d-sm-none mt-1" href={url.url} onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }}>
-                    <img className="img-fluid" style={{ width: 40 }} src={url.domain_logo} alt="" />
-                </A>
-            </div>
+        <div className="pt-product-item" key={url.url}>
+          <div className="d-flex flex-column align-items-center">
+              <LogoPlaceHolder className="pt-product-logo" url={url} />
+              <A className="d-block d-sm-none mt-1" href={url.url} onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }}>
+                  <img className="img-fluid" style={{ width: 40 }} src={url.domain_logo} alt="" />
+              </A>
+          </div>
 
+          <div className="pt-product-body">
+              <div className="pt-product-title">
+                  { url.inventory_status === false
+                    ? <span className="pt-badge pt-badge-danger mr-1">{OUT_OF_STOCK}</span>
+                    : '' }
 
-            <p className="media-body ml-3 pb-3 mb-0 small lh-125">
-                <strong className="text-gray-dark">
-                    { url.inventory_status === false
-                      ? <span className="badge badge-danger mr-1" style={{ fontSize: '1em', fontWeight: 300 }}>{OUT_OF_STOCK}</span>
-                      : '' }
+                  <Link to={`/view/${url.id}`}>
+                  {url.info ? url.info.name : url.domain}
+                  </Link>
+              </div>
 
-                    <Link to={`/view/${url.id}`}>
-                    {url.info ? url.info.name : url.domain}
-                    </Link>
-                </strong>
+              <span className="pt-product-price-value">{formatPrice(url.latest_price, false, url.info.currency)} </span>
+              {
+                  url.price_change
+                    ? <span className={`pt-product-price-change ${url.price_change < 0 ? 'pt-price-down' : 'pt-price-up'}`}>
+                          <FontAwesomeIcon
+                            icon={url.price_change < 0 ? faCaretDown : faCaretUp } />
+                          {formatPrice(url.price_change, true, url.info.currency)}
+                      </span>
+                    : ''
+              }
 
-                <span className="ml-3">{formatPrice(url.latest_price, false, url.info.currency)} </span>
-                {
-                    url.price_change
-                      ? <span className="ml-2" style={{ fontWeight: 700, color: url.price_change < 0 ? '#28a745' : '#f44336' }}>
-                            <FontAwesomeIcon
-                              icon={url.price_change < 0 ? faCaretDown : faCaretUp } />
-                            {formatPrice(url.price_change, true, url.info.currency)}
-                        </span>
-                      : ''
-                }
+              <br />
 
-                <br />
+              <A href={url.url} onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }} style={{ color: '#797979 !important' }}>
+                  {url.url.length > 100 ? `${url.url.slice(0, 100)}...` : url.url}
+              </A>
+              <br />
 
-                <A href={url.url} onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }} style={{ color: '#797979 !important' }}>
-                    {url.url.length > 100 ? `${url.url.slice(0, 100)}...` : url.url}
-                </A>
-                <br />
-
-                <A href={url.url} className='btn btn-primary btn-sm mt-2 mb-2 mr-1'
+              <div className="pt-product-actions mt-2 mb-2">
+                <A href={url.url} className='pt-btn pt-btn-primary pt-btn-sm'
                     onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }}>
                     <FontAwesomeIcon icon={faShoppingCart} /> {GO_TO} {url.domain}
                 </A>
-                <Link className='btn btn-default btn-sm mt-2 mb-2 mr-1' to={`/view/${url.id}`}>
+                <Link className='pt-btn pt-btn-secondary pt-btn-sm' to={`/view/${url.id}`}>
                     <FontAwesomeIcon icon={faHistory} /> {VIEW_HISTORY}
                 </Link>
+              </div>
 
-                <br />
+              <br />
 
-                <small>
-                    <A href={`/view/${url.id}`}>{ADD_BY} {url.add_by}</A> | &nbsp;
-                    {url.deeplinkClick ? `${url.deeplinkClick} click${url.deeplinkClick > 1 ? 's' : ''} | ` : ''}
-                    {CREATE_AT} {moment(url.created_at).fromNow()} | &nbsp;
-                    {LAST_PULL_AT}: {moment(url.last_pull_at).fromNow()}
-                </small>
-            </p>
+              <small className="pt-product-meta">
+                  <A href={`/view/${url.id}`}>{ADD_BY} {url.add_by}</A> | &nbsp;
+                  {url.deeplinkClick ? `${url.deeplinkClick} click${url.deeplinkClick > 1 ? 's' : ''} | ` : ''}
+                  {CREATE_AT} {moment(url.created_at).fromNow()} | &nbsp;
+                  {LAST_PULL_AT}: {moment(url.last_pull_at).fromNow()}
+              </small>
           </div>
 
-          <div className="mb-3 mr-3 d-none d-sm-block" style={{ width: 100 }}>
+          <div className="d-none d-sm-block" style={{ width: 100 }}>
             <Link to={url.url} onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }}>
-                <img className="ml-3 img-fluid" style={{ width: 100 }} src={url.domain_logo} alt="" />
+                <img className="img-fluid" style={{ width: 100 }} src={url.domain_logo} alt="" />
             </Link>
           </div>
         </div>
@@ -94,7 +93,7 @@ class ProductList extends React.Component {
 
     if (this.props.loadMore) {
       dom.push(
-        <span className="btn btn-lg btn-block btn-warning mt-5"
+        <span className="pt-btn pt-btn-primary mt-5"
             onClick={this.props.onClickLoadMore}
             key="load-more-btn">
             {LOAD_MORE}

--- a/hosting/src/components/Block/SortControl.js
+++ b/hosting/src/components/Block/SortControl.js
@@ -19,10 +19,9 @@ export default class SortControl extends PureComponent {
       }
 
       return (
-          <span className="text-white ml-2 btn"
+          <span className={`pt-sort-btn ${currentMode === mode ? 'active' : ''}`}
                 key={mode}
-                onClick={() => this.setOtherBy(mode)}
-                style={{ fontWeight: currentMode === mode ? 700 : 300 }}>
+                onClick={() => this.setOtherBy(mode)}>
                 {sortText[mode]}
                 {sortIcon}
             </span>

--- a/hosting/src/components/Block/Stats.js
+++ b/hosting/src/components/Block/Stats.js
@@ -33,7 +33,7 @@ export default class Stats extends Component {
     if (!Object.keys(this.state.statistics).length) return 'No info';
 
     return (
-      <table className="table table-bordered">
+      <table className="pt-table">
         <tbody>
           <tr>
               <td style={{ textAlign: 'right' }}>{NUM_URL_TEXT}</td>

--- a/hosting/src/components/Block/SubscribeBox.js
+++ b/hosting/src/components/Block/SubscribeBox.js
@@ -145,7 +145,7 @@ class SubscribeBox extends Component {
             <React.Fragment>
                 { this.state.error ? <FlashMessage /> : null }
 
-                <form className="row align-items-start bg-white mt-3 mb-3 ml-1 mr-1 p-3 rounded shadow-sm"
+                <form className="pt-subscribe-box"
                     style={{ fontSize: '0.8em' }}>
                     <div className="col-auto mb-3">
                         <h6>{SUBSCRIBE_THIS_URL}</h6>

--- a/hosting/src/components/Header/addUrlForm.js
+++ b/hosting/src/components/Header/addUrlForm.js
@@ -56,7 +56,7 @@ class AddUrlForm extends Component {
     render() {
       return (
             <form onSubmit={this.onSubmit}>
-                <input className="form-control mr-sm-2" type="search"
+                <input className="pt-search-input" type="search"
                        placeholder="URL e.g. tiki.vn, shopee.vn"
                        onChange={this.onChangeInput}
                        value={this.state.inputUrl}

--- a/hosting/src/components/Header/header.css
+++ b/hosting/src/components/Header/header.css
@@ -1,13 +1,1 @@
-.blog-header {
-  line-height: 1;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.blog-header-logo {
-  font-family: "Playfair Display", Georgia, "Times New Roman", serif;
-  font-size: 2.25rem;
-}
-
-.blog-header-logo:hover {
-  text-decoration: none;
-}
+/* Header styles are now handled by design-system.css (.pt-header, .pt-header-inner, etc.) */

--- a/hosting/src/components/Header/index.js
+++ b/hosting/src/components/Header/index.js
@@ -21,10 +21,9 @@ const SIGN_IN = 'Đăng nhập';
 const TITLE = 'Theo dõi giá và hoàn tiền | Price tracker & Cashback';
 
 const UserButton = ({ authUser, onClickSignIn, onClickProfile }) => {
-  const className = 'btn btn-sm btn-outline-secondary ml-2';
   if (!authUser) {
     return (
-      <button className={className} onClick={onClickSignIn}>
+      <button className="pt-btn pt-btn-secondary pt-btn-sm" onClick={onClickSignIn}>
         {SIGN_IN} <FontAwesomeIcon icon={faGoogle} />
       </button>
     );
@@ -32,10 +31,10 @@ const UserButton = ({ authUser, onClickSignIn, onClickProfile }) => {
 
   return (
     <Fragment>
-      <button className={`${className} d-none d-sm-block`} onClick={onClickProfile}>
+      <button className="pt-btn pt-btn-secondary pt-btn-sm d-none d-sm-inline-flex" onClick={onClickProfile}>
         {authUser.displayName}
       </button>
-      <button className='btn btn-link text-muted d-block d-sm-none' onClick={onClickProfile}>
+      <button className="pt-btn-text d-block d-sm-none" onClick={onClickProfile}>
         <img src={profileIcon} style={{ width: 20 }} alt="" />
       </button>
     </Fragment>
@@ -52,16 +51,16 @@ const NavigationAuth = ({
       <meta charSet="utf-8" />
       <title>{TITLE}</title>
     </Helmet>
-    <header className="blog-header py-3">
-      <div className="row flex-nowrap justify-content-between align-items-center">
-        <div className="col-auto">
+    <header className="pt-header">
+      <div className="pt-header-inner">
+        <div>
           <Logo />
         </div>
-        <div className="col">
+        <div className="pt-search-form">
           <AddUrlForm authUser={authUser} inputUrl={inputUrl} firebase={firebase} />
         </div>
-        <div className="col-auto">
-          <div className="d-flex justify-content-end align-items-center">
+        <div>
+          <div className="d-flex justify-content-end align-items-center" style={{ gap: '8px' }}>
             <A className="text-muted" href="/" >
               <img src={notiIcon} alt="" />
             </A>

--- a/hosting/src/components/Header/menu.js
+++ b/hosting/src/components/Header/menu.js
@@ -4,20 +4,18 @@ import { Link } from 'gatsby';
 import MENUS from '../../constants/menu';
 
 export default ({ authUser }) => (
-    <div className="nav-scroller py-1 mb-2">
-        <nav className="nav d-flex justify-content-center">
-            {
-                MENUS.map((item) => {
-                  if (item.auth && !authUser) return null;
-                  return (
-                        <Link key={item.path}
-                            className="p-2 text-muted"
-                            to={item.path} activeStyle={{ fontWeight: 700 }}>
-                            {item.text}
-                        </Link>
-                  );
-                })
-            }
-        </nav>
+    <div className="pt-nav" style={{ justifyContent: 'center', marginBottom: '8px' }}>
+        {
+            MENUS.map((item) => {
+              if (item.auth && !authUser) return null;
+              return (
+                    <Link key={item.path}
+                        to={item.path}
+                        activeStyle={{ fontWeight: 700 }}>
+                        {item.text}
+                    </Link>
+              );
+            })
+        }
     </div>
 );

--- a/hosting/src/components/layout.css
+++ b/hosting/src/components/layout.css
@@ -1,83 +1,11 @@
-.bd-placeholder-img {
-  font-size: 1.125rem;
-  text-anchor: middle;
-}
-
-@media (min-width: 768px) {
-  .bd-placeholder-img-lg {
-    font-size: 3.5rem;
-  }
-}
+/* Layout overrides — kept for Bootstrap grid utilities only */
+/* Design system (design-system.css) handles header, nav, cards, hero, etc. */
 
 html,
 body {
   overflow-x: hidden; /* Prevent scroll on narrow devices */
 }
 
-@media (max-width: 991.98px) {
-  .offcanvas-collapse {
-    position: fixed;
-    top: 56px; /* Height of navbar */
-    bottom: 0;
-    left: 100%;
-    width: 100%;
-    padding-right: 1rem;
-    padding-left: 1rem;
-    overflow-y: auto;
-    visibility: hidden;
-    background-color: #343a40;
-    transition-timing-function: ease-in-out;
-    transition-duration: .3s;
-    transition-property: left, visibility;
-  }
-  .offcanvas-collapse.open {
-    left: 0;
-    visibility: visible;
-  }
-}
-
-.nav-scroller {
-  position: relative;
-  z-index: 2;
-  height: 2.75rem;
-  overflow-y: hidden;
-}
-
-.nav-scroller .nav {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-bottom: 1rem;
-  margin-top: -1px;
-  overflow-x: auto;
-  color: rgba(255, 255, 255, .75);
-  text-align: center;
-  white-space: nowrap;
-  -webkit-overflow-scrolling: touch;
-}
-
-.nav-underline .nav-link {
-  padding-top: .75rem;
-  padding-bottom: .75rem;
-  font-size: .875rem;
-  color: #6c757d;
-}
-
-.nav-underline .nav-link:hover {
-  color: #007bff;
-}
-
-.nav-underline .active {
-  font-weight: 500;
-  color: #343a40;
-}
-
-.text-white-50 { color: rgba(255, 255, 255, .5); }
-
-.bg-purple { background-color: #6f42c1; }
-
 .lh-100 { line-height: 1; }
 .lh-125 { line-height: 1.25; }
 .lh-150 { line-height: 1.5; }
-

--- a/hosting/src/components/layout.js
+++ b/hosting/src/components/layout.js
@@ -5,11 +5,12 @@ import withAuthentication from './Session/withAuthentication';
 
 import './layout.css';
 import 'bootstrap/dist/css/bootstrap.css';
+import '../styles/design-system.css';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
 const AppWithAuthentication = withAuthentication(({ children, inputUrl }) => (
   <Fragment>
-    <div className="container">
+    <div className="pt-container">
       <Header inputUrl={inputUrl} />
       <main role="main">
         {children}

--- a/hosting/src/pages/about.js
+++ b/hosting/src/pages/about.js
@@ -17,11 +17,11 @@ export default class IndexComponent extends Component {
     render() {
       return (
             <Layout>
-                <div className="d-flex align-items-center p-3 my-3 text-white-50 rounded shadow-sm" style={{ background: '#03A9F4' }}>
+                <div className="pt-hero">
                     <HeadSlogan icon="image" sub_headline="Giới thiệu" />
                 </div>
 
-                <div className="my-3 p-3 bg-white rounded shadow-sm row">
+                <div className="pt-card my-3 row">
                     <div className="col mb-3">
                         Pricetrack là ứng dụng theo dõi giá trên các trang TMDT lớn
                         như tiki.vn, shopee.vn,... hoàn toàn miễn phí <br />

--- a/hosting/src/pages/cashback.js
+++ b/hosting/src/pages/cashback.js
@@ -225,10 +225,10 @@ class CashbackBalance extends Component {
 
     return (
       <>
-        <div className="d-flex justify-content-center my-3 p-3 bg-white rounded shadow-sm text-center">
+        <div className="pt-card d-flex justify-content-center my-3 text-center">
           <div className="mr-5">
             <span>{YOUR_CASHBACK_BALANCE}: </span>
-            <span style={{ color: '#1791d3', fontWeight: 700 }}>{this._price()}</span>
+            <span className="pt-product-price-value">{this._price()}</span>
             <div>
               <small><em>({UPDATING})</em></small>
             </div>
@@ -236,7 +236,7 @@ class CashbackBalance extends Component {
 
           <div>
             <span>{YOUR_CASHBACK_BALANCE_CHECKED_OUT}: </span>
-            <span style={{ color: '#1791d3', fontWeight: 700 }}>0 VND</span>
+            <span className="pt-product-price-value">0 VND</span>
             <div>
               <small><em></em></small>
             </div>
@@ -291,11 +291,11 @@ class IndexComponent extends Component {
     if (typeof window === 'undefined') return null;
     return (
       <Layout>
-        <div className="d-flex align-items-center p-3 my-3 text-white-50 rounded shadow-sm" style={{ background: '#03A9F4' }}>
+        <div className="pt-hero">
           <HeadSlogan icon="checkmark" sub_headline="cashback" />
         </div>
 
-        <div className="my-3 p-3 bg-white rounded shadow-sm row">
+        <div className="pt-card my-3 row">
           <div className="col mb-3" style={{ fontSize: 13 }}>
             Cashback là chức năng nhận lại tiền hoàn trả từ Pricetrack.
             Lưu ý:

--- a/hosting/src/pages/index.js
+++ b/hosting/src/pages/index.js
@@ -126,10 +126,10 @@ class IndexComponent extends PureComponent {
     render() {
       return (
             <Layout>
-                <div className="d-flex align-items-center p-3 my-3 text-white-50 rounded shadow-sm" style={{ background: '#03A9F4' }}>
+                <div className="pt-hero">
                     <HeadSlogan />
 
-                    <div className="lh-100 mr-0 p-2 bd-highlight text-white justify-content-end">
+                    <div className="pt-sort-controls">
                       <SortControl
                           sortText={SORT_TEXT}
                           currentMode={this.state.currentMode}
@@ -137,7 +137,7 @@ class IndexComponent extends PureComponent {
                     </div>
                 </div>
 
-                <div className="my-3 p-3 bg-white rounded shadow-sm" id="listUrls">
+                <div className="pt-card my-3" id="listUrls">
                     {this.renderListUrl()}
                 </div>
             </Layout>

--- a/hosting/src/pages/my_product.js
+++ b/hosting/src/pages/my_product.js
@@ -124,10 +124,10 @@ class MyProductComponent extends PureComponent {
     render() {
       return (
             <Layout>
-                <div className="d-flex align-items-center p-3 my-3 text-white-50 rounded shadow-sm" style={{ background: '#03A9F4' }}>
+                <div className="pt-hero">
                     <HeadSlogan sub_headline={SUB_HEADLINE} />
 
-                    <div className="lh-100 mr-0 p-2 bd-highlight text-white">
+                    <div className="pt-sort-controls">
                         <SortControl
                           sortText={SORT_TEXT}
                           currentMode={this.state.currentMode}
@@ -135,7 +135,7 @@ class MyProductComponent extends PureComponent {
                    </div>
                 </div>
 
-                <div className="my-3 p-3 bg-white rounded shadow-sm" id="listUrls">
+                <div className="pt-card my-3" id="listUrls">
                     {this.renderListUrl()}
                 </div>
             </Layout>

--- a/hosting/src/pages/profile.js
+++ b/hosting/src/pages/profile.js
@@ -50,11 +50,11 @@ class Profile extends React.Component {
 
     return (
             <Layout>
-                <div className="container" style={style.textSm}>
-                    <div className="row my-3 p-3 bg-white rounded shadow-sm">
+                <div style={style.textSm}>
+                    <div className="pt-card row my-3">
                         <div className="col border-bottom border-light mb-3 p-3 d-flex flex-column justify-content-center">
                             <div className="d-flex flex-column justify-content-center mx-auto text-center">
-                                <img src={authUser.photoURL} style={{ maxWidth: 150 }} className="img-fluid rounded mb-3" alt="..." />
+                                <img src={authUser.photoURL} className="pt-profile-avatar mb-3" alt="..." />
                                 <h6>{authUser.displayName}</h6>
                                 <small>{authUser.email}</small>
                             </div>

--- a/hosting/src/pages/view.js
+++ b/hosting/src/pages/view.js
@@ -147,59 +147,65 @@ class ViewPage extends Component {
       return (
             <Layout inputUrl={this.state.inputUrl}>
 
-                <div className="d-flex justify-content-between align-items-center bg-white p-3 my-3 rounded shadow-sm">
-                    <div className="d-flex flex-row justify-content-between">
-                        <LogoPlaceHolder url={url} width={80} height={80} />
-                        <div className="lh-100 ml-3">
-                        { url.inventory_status === false
-                          ? <span className="badge badge-danger mr-1" style={{ fontSize: '1em', fontWeight: 300 }}>{OUT_OF_STOCK}</span>
-                          : '' }
-                            <a href={this.state.data.url}
-                                onClick={(e) => { openDeepLink(url.redirect); e.preventDefault(); }}
-                                style={{ color: url.color }}>
-                                <h6 className="mb-0 lh-100">
-                                    {this.state.data.info.name}
-                                    <FontAwesomeIcon icon={faExternalLinkAlt} className="ml-2" style={{ fontWeight: 300, fontSize: 12 }} />
-                                </h6>
-                            </a>
-                            <br />
-                            <small className="mb-3" style={{ color: '#000', fontWeight: 700 }}>
-                                {formatPrice(this.state.data.latest_price,
-                                  false, this.state.data.info.currency)}
-                                <span style={{ fontWeight: 700, color: this.state.data.price_change < 0 ? '#0eff45' : '#fd4d16' }} className='ml-1'>
-                                    {
-                                        this.state.data.price_change
-                                          ? `(${formatPrice(this.state.data.price_change, true)})`
-                                          : ''
-                                    }
-                                </span>
-                            </small>
-                            <br />
-                            <br />
-                            <a href={url.url} className='btn btn-primary btn-sm mr-1'
+                <div className="pt-card my-3">
+                    <div className="d-flex flex-row justify-content-between align-items-center">
+                        <div className="d-flex flex-row justify-content-between">
+                            <LogoPlaceHolder url={url} width={80} height={80} />
+                            <div className="ml-3">
+                            { url.inventory_status === false
+                              ? <span className="pt-badge pt-badge-danger mr-1">{OUT_OF_STOCK}</span>
+                              : '' }
+                                <a href={this.state.data.url}
                                     onClick={(e) => {
                                       openDeepLink(url.redirect);
                                       e.preventDefault();
-                                    }}>
-                                    <FontAwesomeIcon icon={faShoppingCart} /> {GO_TO} {url.domain}
-                            </a>
+                                    }}
+                                    style={{ color: url.color }}>
+                                    <h6 className="mb-0 lh-100">
+                                        {this.state.data.info.name}
+                                        <FontAwesomeIcon icon={faExternalLinkAlt} className="ml-2" style={{ fontWeight: 300, fontSize: 12 }} />
+                                    </h6>
+                                </a>
+                                <br />
+                                <small className="mb-3">
+                                    <span className="pt-product-price-value">{formatPrice(this.state.data.latest_price,
+                                      false, this.state.data.info.currency)}</span>
+                                    <span className={`pt-product-price-change ${this.state.data.price_change < 0 ? 'pt-price-down' : 'pt-price-up'}`}>
+                                        {
+                                            this.state.data.price_change
+                                              ? `(${formatPrice(this.state.data.price_change, true)})`
+                                              : ''
+                                        }
+                                    </span>
+                                </small>
+                                <br />
+                                <br />
+                                <a href={url.url} className='pt-btn pt-btn-primary pt-btn-sm mr-1'
+                                        onClick={(e) => {
+                                          openDeepLink(url.redirect);
+                                          e.preventDefault();
+                                        }}>
+                                        <FontAwesomeIcon icon={faShoppingCart} />
+                                        {' '}{GO_TO} {url.domain}
+                                </a>
 
-                            <small className="ml-3">
-                                {url.deeplinkClick ? `${url.deeplinkClick} click${url.deeplinkClick > 1 ? 's' : ''} | ` : ''}
-                                {CREATE_AT} {moment(url.created_at).fromNow()} | &nbsp;
-                                {LAST_PULL_AT}: {moment(url.last_pull_at).fromNow()}
-                            </small>
+                                <small className="ml-3 pt-product-meta">
+                                    {url.deeplinkClick ? `${url.deeplinkClick} click${url.deeplinkClick > 1 ? 's' : ''} | ` : ''}
+                                    {CREATE_AT} {moment(url.created_at).fromNow()} | &nbsp;
+                                    {LAST_PULL_AT}: {moment(url.last_pull_at).fromNow()}
+                                </small>
+                            </div>
                         </div>
-                    </div>
 
-                    <div className="lh-100 my-3">
-                        <a href={url.url}
-                          onClick={(e) => {
-                            openDeepLink(url.redirect);
-                            e.preventDefault();
-                          }}>
-                            <img className="ml-3 img-fluid" style={{ height: 40 }} src={url.domain_logo} alt="" />
-                        </a>
+                        <div className="my-3">
+                            <a href={url.url}
+                              onClick={(e) => {
+                                openDeepLink(url.redirect);
+                                e.preventDefault();
+                              }}>
+                                <img className="img-fluid" style={{ height: 40 }} src={url.domain_logo} alt="" />
+                            </a>
+                        </div>
                     </div>
                 </div>
 

--- a/hosting/src/styles/design-system.css
+++ b/hosting/src/styles/design-system.css
@@ -1,0 +1,676 @@
+/* ============================================================
+   PriceTrack — Anthropic-Inspired Design System
+   Based on DESIGN.md: warm cream canvas, coral CTAs, dark navy surfaces
+   ============================================================ */
+
+/* --- CSS Custom Properties (Design Tokens) --- */
+:root {
+  /* Brand & Accent */
+  --color-primary: #cc785c;
+  --color-primary-active: #a9583e;
+  --color-primary-disabled: #e6dfd8;
+  --color-accent-teal: #5db8a6;
+  --color-accent-amber: #e8a55a;
+
+  /* Surfaces */
+  --color-canvas: #faf9f5;
+  --color-surface-soft: #f5f0e8;
+  --color-surface-card: #efe9de;
+  --color-surface-cream-strong: #e8e0d2;
+  --color-surface-dark: #181715;
+  --color-surface-dark-elevated: #252320;
+  --color-surface-dark-soft: #1f1e1b;
+
+  /* Borders */
+  --color-hairline: #e6dfd8;
+  --color-hairline-soft: #ebe6df;
+
+  /* Text */
+  --color-ink: #141413;
+  --color-body-strong: #252523;
+  --color-body: #3d3d3a;
+  --color-muted: #6c6a64;
+  --color-muted-soft: #8e8b82;
+  --color-on-primary: #ffffff;
+  --color-on-dark: #faf9f5;
+  --color-on-dark-soft: #a09d96;
+
+  /* Semantic */
+  --color-success: #5db872;
+  --color-warning: #d4a017;
+  --color-error: #c64545;
+
+  /* Spacing */
+  --space-xxs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-xxl: 48px;
+  --space-section: 96px;
+
+  /* Border Radius */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+
+  /* Typography */
+  --font-display: 'Cormorant Garamond', 'Garamond', 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-code: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+  /* Shadows */
+  --shadow-subtle: 0 1px 3px rgba(20, 20, 19, 0.08);
+}
+
+/* --- Base Reset & Typography --- */
+body {
+  background-color: var(--color-canvas);
+  color: var(--color-body);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  color: var(--color-ink);
+  letter-spacing: -0.02em;
+}
+
+h1 { font-size: 36px; line-height: 1.15; letter-spacing: -0.5px; }
+h2 { font-size: 28px; line-height: 1.2; letter-spacing: -0.3px; }
+h3 { font-size: 22px; line-height: 1.3; }
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* --- Layout Container --- */
+.pt-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+}
+
+/* --- Header / Navigation --- */
+.pt-header {
+  background-color: var(--color-canvas);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: var(--space-md) 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.pt-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.pt-logo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-display);
+  font-size: 20px;
+  color: var(--color-ink);
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.pt-logo:hover {
+  text-decoration: none;
+  color: var(--color-ink);
+}
+
+.pt-logo img {
+  height: 36px;
+  width: 36px;
+}
+
+.pt-logo-mark {
+  color: var(--color-primary);
+  font-size: 24px;
+  line-height: 1;
+}
+
+/* --- Navigation Menu --- */
+.pt-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.pt-nav a,
+.pt-nav Link {
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-muted);
+  text-decoration: none;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.pt-nav a:hover,
+.pt-nav a.active {
+  background-color: var(--color-surface-card);
+  color: var(--color-ink);
+  text-decoration: none;
+}
+
+/* --- URL Search Form --- */
+.pt-search-form {
+  flex: 1;
+  max-width: 480px;
+}
+
+.pt-search-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-md);
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.pt-search-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(204, 120, 92, 0.15);
+}
+
+.pt-search-input::placeholder {
+  color: var(--color-muted-soft);
+}
+
+/* --- Buttons --- */
+.pt-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: 10px 20px;
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  border: none;
+  transition: background-color 0.15s;
+}
+
+.pt-btn-primary {
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.pt-btn-primary:hover {
+  background-color: var(--color-primary-active);
+  text-decoration: none;
+  color: var(--color-on-primary);
+}
+
+.pt-btn-secondary {
+  background-color: var(--color-canvas);
+  color: var(--color-ink);
+  border: 1px solid var(--color-hairline);
+}
+
+.pt-btn-secondary:hover {
+  background-color: var(--color-surface-soft);
+}
+
+.pt-btn-sm {
+  padding: 6px 14px;
+  font-size: 13px;
+  border-radius: var(--radius-sm);
+}
+
+.pt-btn-text {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  padding: 6px 10px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.pt-btn-text:hover {
+  text-decoration: underline;
+}
+
+/* --- Cards --- */
+.pt-card {
+  background-color: var(--color-surface-card);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+}
+
+.pt-card-canvas {
+  background-color: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+}
+
+.pt-card-dark {
+  background-color: var(--color-surface-dark);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+  color: var(--color-on-dark);
+}
+
+/* --- Hero / Slogan Bar --- */
+.pt-hero {
+  background-color: var(--color-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl) var(--space-xl);
+  color: var(--color-on-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.pt-hero-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.pt-hero-icon img {
+  width: 28px;
+  height: 28px;
+}
+
+.pt-hero h2 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  color: var(--color-on-primary);
+  margin: 0;
+  letter-spacing: -0.3px;
+}
+
+.pt-hero p {
+  margin: 4px 0 0;
+  opacity: 0.85;
+  font-size: 14px;
+}
+
+/* --- Product List --- */
+.pt-product-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.pt-product-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--color-hairline-soft);
+}
+
+.pt-product-item:last-child {
+  border-bottom: none;
+}
+
+.pt-product-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.pt-product-logo-placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--color-muted);
+  flex-shrink: 0;
+}
+
+.pt-product-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.pt-product-title {
+  font-weight: 500;
+  color: var(--color-ink);
+  font-size: 15px;
+  margin-bottom: 2px;
+}
+
+.pt-product-title a {
+  color: var(--color-ink);
+}
+
+.pt-product-title a:hover {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.pt-product-meta {
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.pt-product-price {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.pt-product-price-value {
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--color-ink);
+}
+
+.pt-product-price-change {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pt-price-down { color: var(--color-success); }
+.pt-price-up { color: var(--color-error); }
+
+.pt-product-actions {
+  display: flex;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+/* --- Sort Controls --- */
+.pt-sort-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.pt-sort-btn {
+  padding: var(--space-xs) var(--space-sm);
+  border: none;
+  background: none;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--color-on-dark-soft, rgba(255, 255, 255, 0.6));
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.15s;
+}
+
+.pt-sort-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.pt-sort-btn.active {
+  font-weight: 700;
+  color: var(--color-on-dark);
+}
+
+/* --- Badge --- */
+.pt-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.pt-badge-warning {
+  background: var(--color-accent-amber);
+  color: var(--color-ink);
+}
+
+.pt-badge-success {
+  background: var(--color-success);
+  color: var(--color-on-primary);
+}
+
+.pt-badge-danger {
+  background: var(--color-error);
+  color: var(--color-on-primary);
+}
+
+.pt-badge-muted {
+  background: var(--color-surface-card);
+  color: var(--color-ink);
+}
+
+/* --- Subscribe Box --- */
+.pt-subscribe-box {
+  background: var(--color-surface-card);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  margin: var(--space-lg) 0;
+  font-size: 14px;
+}
+
+.pt-subscribe-box label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  cursor: pointer;
+  color: var(--color-body);
+}
+
+.pt-subscribe-box input[type="checkbox"],
+.pt-subscribe-box input[type="radio"] {
+  accent-color: var(--color-primary);
+}
+
+.pt-subscribe-box input[type="number"],
+.pt-subscribe-box input[type="text"] {
+  padding: 8px 12px;
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-md);
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+/* --- Tables --- */
+.pt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.pt-table th {
+  font-weight: 600;
+  color: var(--color-ink);
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border-bottom: 2px solid var(--color-hairline);
+}
+
+.pt-table td {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--color-hairline-soft);
+  color: var(--color-body);
+}
+
+.pt-table tr:hover td {
+  background-color: var(--color-surface-soft);
+}
+
+/* --- Form Controls (override Bootstrap) --- */
+.form-control {
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-md);
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+  padding: 10px 14px;
+  transition: border-color 0.15s;
+}
+
+.form-control:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(204, 120, 92, 0.15);
+  outline: none;
+}
+
+/* --- Loading Spinner --- */
+.pt-loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-xxl) 0;
+}
+
+.pt-loading-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  margin: 0 4px;
+  animation: pt-pulse 1.2s ease-in-out infinite;
+}
+
+.pt-loading-dot:nth-child(2) { animation-delay: 0.2s; }
+.pt-loading-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes pt-pulse {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+/* --- Flash Message --- */
+.pt-flash {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  background: var(--color-error);
+  color: var(--color-on-primary);
+  font-size: 14px;
+  padding: var(--space-sm);
+  z-index: 1000;
+}
+
+/* --- Profile --- */
+.pt-profile-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--color-hairline);
+}
+
+/* --- Footer --- */
+.pt-footer {
+  background-color: var(--color-surface-dark);
+  color: var(--color-on-dark-soft);
+  padding: var(--space-xxl) 0;
+  margin-top: var(--space-section);
+  font-size: 14px;
+}
+
+.pt-footer a {
+  color: var(--color-on-dark);
+}
+
+/* --- Utility Overrides --- */
+.bg-white { background-color: var(--color-canvas) !important; }
+.bg-light { background-color: var(--color-surface-soft) !important; }
+.text-muted { color: var(--color-muted) !important; }
+.text-white { color: var(--color-on-primary) !important; }
+.text-white-50 { color: rgba(255, 255, 255, 0.7) !important; }
+.border-bottom { border-bottom: 1px solid var(--color-hairline) !important; }
+.shadow-sm { box-shadow: var(--shadow-subtle) !important; }
+.rounded { border-radius: var(--radius-lg) !important; }
+
+/* Hide Bootstrap colors */
+.btn-primary {
+  background-color: var(--color-primary) !important;
+  border-color: var(--color-primary) !important;
+  color: var(--color-on-primary) !important;
+}
+.btn-primary:hover {
+  background-color: var(--color-primary-active) !important;
+  border-color: var(--color-primary-active) !important;
+}
+.btn-outline-secondary {
+  color: var(--color-ink) !important;
+  border-color: var(--color-hairline) !important;
+}
+.btn-outline-secondary:hover {
+  background-color: var(--color-surface-soft) !important;
+  border-color: var(--color-hairline) !important;
+  color: var(--color-ink) !important;
+}
+
+.badge-warning {
+  background-color: var(--color-accent-amber) !important;
+  color: var(--color-ink) !important;
+}
+.badge-success {
+  background-color: var(--color-success) !important;
+}
+.badge-danger {
+  background-color: var(--color-error) !important;
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .pt-header-inner {
+    flex-wrap: wrap;
+  }
+  .pt-search-form {
+    order: 3;
+    max-width: 100%;
+    width: 100%;
+  }
+  .pt-product-item {
+    flex-wrap: wrap;
+  }
+  .pt-product-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+  .pt-hero {
+    padding: var(--space-lg);
+  }
+  .pt-hero h2 {
+    font-size: 22px;
+  }
+}


### PR DESCRIPTION
## Summary

Complete frontend visual redesign following the Anthropic design language from DESIGN.md.

### Design System
- **Canvas**: Warm cream `#faf9f5` (not cool gray)
- **Primary**: Coral `#cc785c` for CTAs and hero bars
- **Dark surface**: Navy `#181715` for code/editor mockups
- **Typography**: Serif display (Cormorant Garamond) + sans body (Inter)
- **Cards**: Cream surface-card `#efe9de` — no shadows, color-block depth
- **Spacing**: 4px base unit, 96px section rhythm

### Changes (22 files, zero logic changes)
- New `design-system.css` with CSS custom properties for all tokens
- All hero bars changed from blue `#03A9F4` to coral `pt-hero`
- Product list, cards, buttons, tables, badges all restyled
- Hardcoded inline colors replaced with semantic CSS classes
- Price indicators use `pt-price-down` (green) / `pt-price-up` (red)
- Loading spinner uses animated dot pulse
- Manifest updated to cream/coral theme colors

### Before → After
| Element | Before | After |
|---------|--------|-------|
| Background | White `#fff` | Cream `#faf9f5` |
| Hero bars | Blue `#03A9F4` | Coral `#cc785c` |
| Headlines | System sans | Serif (Cormorant Garamond) |
| Cards | White + shadow | Cream `#efe9de` no shadow |
| Buttons | Bootstrap blue | Coral primary |
| Tables | Bootstrap default | Minimal cream styling |

### Verification
- ✅ Lint passes (zero errors)
- ✅ Gatsby build succeeds (9/9 pages)