### PR TITLE
ci: migrate Firebase deploy to service account auth

### DIFF
--- a/.github/workflows/deploy_functions.yml
+++ b/.github/workflows/deploy_functions.yml
@@ -22,8 +22,10 @@ jobs:
           npm install
           npm run lint
       - name: Deploy functions
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
           cd functions
           npm install
-          export FIREBASE_TOKEN=${{ secrets.FIREBASE_TOKEN }}
           npm run deploy

--- a/.github/workflows/deploy_hosting.yml
+++ b/.github/workflows/deploy_hosting.yml
@@ -23,7 +23,10 @@ jobs:
           npm install
           npm run lint
       - name: Deploy hosting
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
           cd hosting
           npm install
           echo "GATSBY_API_KEY=${{ secrets.GATSBY_API_KEY }}"                           > .env
@@ -35,5 +38,4 @@ jobs:
           echo "GATSBY_VAPID_KEY=${{ secrets.GATSBY_VAPID_KEY }}"                       >> .env
           echo "GATSBY_APPID=${{ secrets.GATSBY_APPID }}"                               >> .env
           npm run build
-          export FIREBASE_TOKEN=${{ secrets.FIREBASE_TOKEN }}
           npm run deploy

--- a/.github/workflows/deploy_releases.yml
+++ b/.github/workflows/deploy_releases.yml
@@ -23,10 +23,12 @@ jobs:
           npm install
           npm run lint
       - name: Deploy functions
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
           cd functions
           npm install
-          export FIREBASE_TOKEN=${{ secrets.FIREBASE_TOKEN }}
           npm run deploy
 
   hosting:
@@ -45,7 +47,10 @@ jobs:
           npm install
           npm run lint
       - name: Deploy hosting
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
           cd hosting
           npm install
           echo "GATSBY_API_KEY=${{ secrets.GATSBY_API_KEY }}"                           > .env
@@ -57,7 +62,6 @@ jobs:
           echo "GATSBY_VAPID_KEY=${{ secrets.GATSBY_VAPID_KEY }}"                       >> .env
           echo "GATSBY_APPID=${{ secrets.GATSBY_APPID }}"                               >> .env
           npm run build
-          export FIREBASE_TOKEN=${{ secrets.FIREBASE_TOKEN }}
           npm run deploy
 
   database_storage_firestore:
@@ -69,6 +73,9 @@ jobs:
         with:
           node-version: 20.x
       - name: Deploy Firebase Database, Storage, Firestore config
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
           npm install -g firebase-tools
-          firebase deploy --only database,storage,firestore --token ${{ secrets.FIREBASE_TOKEN }}
+          firebase deploy --only database,storage,firestore --project duyet-price-tracker --non-interactive

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,7 +26,7 @@ exports.alertFromQueue = require('./modules/alert').alertFromQueue
 exports.removeUrl = require('./modules/removeUrl')
 
 // Ping
-exports.ping = require('firebase-functions')
+exports.ping = require('firebase-functions/v1')
     .runWith({ memory: '128MB' })
     .https
     .onRequest((req, res) => res.json({ msg: 'pong' }))

--- a/functions/modules/alertProvider/email.js
+++ b/functions/modules/alertProvider/email.js
@@ -1,5 +1,5 @@
 const nodemailer = require('nodemailer');
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const { formatPrice, hostingUrl, urlFor } = require('../../utils')
 
 // Configure the email transport using the default SMTP transport and a GMail account.

--- a/functions/modules/cronjob.js
+++ b/functions/modules/cronjob.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const {
     asiaRegion,
     db,

--- a/functions/modules/onNewUser.js
+++ b/functions/modules/onNewUser.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const mailTransport = require('../utils/nodemailer')
 const { email: { APP_NAME, FROM_EMAIL } } = require('../utils/constants')
 

--- a/functions/modules/pullData.js
+++ b/functions/modules/pullData.js
@@ -1,6 +1,6 @@
 /* eslint-disable require-atomic-updates */
 const assert = require('assert')
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const {
   asiaRegion,
   db,

--- a/functions/modules/redirect.js
+++ b/functions/modules/redirect.js
@@ -12,7 +12,7 @@ const {
 const app = new Koa()
 const router = new Router()
 
-router.get('/:id?', async (ctx) => {
+router.get('{/:id}', async (ctx) => {
     let urlId = ctx.params.id || ctx.query.id
     let email = ctx.params.email || ''
     let ref = ctx.params.ref || ''

--- a/functions/modules/scheduler.js
+++ b/functions/modules/scheduler.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const {
     getConfig,
     urlFor,

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
     "serve": "firebase serve --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
-    "deploy": "firebase deploy --only functions --token \"$FIREBASE_TOKEN\" --non-interactive",
+    "deploy": "firebase deploy --only functions --project duyet-price-tracker --non-interactive",
     "logs": "firebase functions:log",
     "test": "mocha --reporter spec"
   },

--- a/functions/utils/config.js
+++ b/functions/utils/config.js
@@ -1,4 +1,4 @@
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 
 /**
  * Get config from firebase config

--- a/functions/utils/index.js
+++ b/functions/utils/index.js
@@ -3,7 +3,7 @@ const querystring = require('querystring')
 const fetch = require('node-fetch')
 
 // The Firebase Admin SDK to access the FireStore DB.
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 const admin = require('firebase-admin')
 
 const {

--- a/functions/utils/nodemailer.js
+++ b/functions/utils/nodemailer.js
@@ -1,5 +1,5 @@
 const nodemailer = require('nodemailer');
-const functions = require('firebase-functions')
+const functions = require('firebase-functions/v1')
 
 const gmailEmail = (functions.config().pricetrack || {}).gmail_email
 const gmailPassword = (functions.config().pricetrack || {}).gmail_password

--- a/hosting/package.json
+++ b/hosting/package.json
@@ -9,7 +9,7 @@
     "start": "npm run develop",
     "lint": "eslint .",
     "build": "rm -rf public && gatsby build",
-    "deploy": "firebase deploy --only hosting --token \"$FIREBASE_TOKEN\" --non-interactive",
+    "deploy": "firebase deploy --only hosting --project duyet-price-tracker --non-interactive",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""
   },


### PR DESCRIPTION
## Why

The 2019 `FIREBASE_TOKEN` (`firebase login:ci`) is deprecated and now returns **401** in CI. Google is disabling legacy CI tokens. This migrates both local and CI deploys to a **service account** via `GOOGLE_APPLICATION_CREDENTIALS` (the supported path).

## What changed

**Auth migration**
- All 3 deploy workflows (`deploy_functions`, `deploy_hosting`, `deploy_releases`) now write the `FIREBASE_SERVICE_ACCOUNT` secret to a file and set `GOOGLE_APPLICATION_CREDENTIALS` instead of `--token $FIREBASE_TOKEN`.
- `functions/package.json` + `hosting/package.json` deploy scripts drop `--token`, use `--project duyet-price-tracker --non-interactive`.
- New repo secret `FIREBASE_SERVICE_ACCOUNT` set; old `FIREBASE_TOKEN` secret deleted.

**Required code fixes (surfaced by the recent dependency upgrade, blocked all deploys)**
- `firebase-functions` v6: the default export dropped the Gen 1 API. Switched 9 files to `require('firebase-functions/v1')` to preserve existing behavior.
- `path-to-regexp` v8 (via new `@koa/router`): optional param syntax changed. `redirect.js` route `/:id?` → `{/:id}`.

## Verification (deployed locally via the service account)

- ✅ All ~24 functions deployed; `GET /ping` → `{"msg":"pong"}`, `/about` returns data
- ✅ Hosting deployed to both targets; `pricetrack.web.app` → 200, `/api/about` rewrite → 200
- ✅ Artifact Registry cleanup policy set (3-day) in both regions to cap image storage cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)